### PR TITLE
Fixed ActiveRecord::TypedStore::Behavior#changes infinite looping

### DIFF
--- a/lib/active_record/typed_store/prefix_accessor.rb
+++ b/lib/active_record/typed_store/prefix_accessor.rb
@@ -38,20 +38,20 @@ module ActiveRecord::TypedStore
 
           define_method("#{accessor_key}_changed?") do
             return false unless attribute_changed?(store_attribute)
-            prev_store, new_store = changes[store_attribute]
-            prev_store&.dig(key) != new_store&.dig(key)
+
+            send(store_attribute)&.dig(key) != send("#{store_attribute}_was")&.dig(key)
           end
 
           define_method("#{accessor_key}_change") do
             return unless attribute_changed?(store_attribute)
-            prev_store, new_store = changes[store_attribute]
-            [prev_store&.dig(key), new_store&.dig(key)]
+
+            [send("#{store_attribute}_was")&.dig(key), send(store_attribute)&.dig(key)]
           end
 
           define_method("#{accessor_key}_was") do
             return unless attribute_changed?(store_attribute)
-            prev_store, _new_store = changes[store_attribute]
-            prev_store&.dig(key)
+            
+            send("#{store_attribute}_was")&.dig(key)
           end
 
           define_method("saved_change_to_#{accessor_key}?") do


### PR DESCRIPTION
# Infinite looping in ActiveModel::Dirty methods

## Issue

[`ActiveRecord::TypedStore::Behavior#changes`](https://github.com/Pavel-Guseynov/activerecord-typedstore/blob/master/lib/active_record/typed_store/behavior.rb#L34)

and

`ActiveRecord::TypedStore::PrefixAccessor`'s dynamic methods
[`"#{accessor_key}_changed?"`](https://github.com/Pavel-Guseynov/activerecord-typedstore/blob/master/lib/active_record/typed_store/prefix_accessor.rb#L39), 
[`"#{accessor_key}_change"`](https://github.com/Pavel-Guseynov/activerecord-typedstore/blob/master/lib/active_record/typed_store/prefix_accessor.rb#L45), 
[`"#{accessor_key}_was"`](https://github.com/Pavel-Guseynov/activerecord-typedstore/blob/master/lib/active_record/typed_store/prefix_accessor.rb#L51)

 are broken since `changes`  calls `"#{accessor_key}_changed?"` and vice versa, which causes infinite looping and  `SystemStackError` (stack level too deep).

## Solution

Prevent `PrefixAccessor`'s dynamic methods from using `changes` method. Use original `ActiveModel::Dirty"#{store_attribute}_was"` implementation for getting initial value of attribute.
